### PR TITLE
Increase performance wildly (DOOM works!)

### DIFF
--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -404,7 +404,7 @@ int main(int argc, char *argv[])
 	for(;;)
 	{
 		SDLNet_CheckSockets(socketSet, -1);
-		if (SDLNet_SocketReady(&sdlnet_pcap)) {
+		if (sdlnet_pcap.ready) {
 			pcap_to_dosbox();
 			// Setting socket status manually to non-ready
 			// because read it outside SDLNet.


### PR DESCRIPTION
Before, a packet is waited infinitely from pcap before handling UDP traffic. This lead to behaviour where only one packet can be handled per incoming packet from the LAN. This fixes it by using SDL_Net socketSet which is a wrapper to poll() system call.

Now it's possible to play DOOM thru this!