### PR TITLE
Add timeout option and fix help bug

### DIFF
--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -358,20 +358,25 @@ void clean_shutdown(int signum)
 int main(int argc, char *argv[])
 {
 	int port = 213;
+	int timeout = 0;
 	bool help = false;
 	int c;
 
-	while ((c = getopt (argc, argv, "p:rh")) != -1)
+	while ((c = getopt (argc, argv, "p:t:rh")) != -1)
 		switch (c)
 		{
 		case 'p':
 			port = atoi(optarg);
+			break;
+		case 't':
+			timeout = atoi(optarg);
 			break;
 		case 'r':
 			use_llc = false;
 			break;
 		case 'h':
 			help = true;
+			break;
 		case '?':
 			exit(1);
 		default:
@@ -381,11 +386,13 @@ int main(int argc, char *argv[])
 	// Command line parameters
 	if (optind+1 != argc || help)
 	{
-		errx(1, "Usage: %s IF [-p PORT]\n\n"
+		errx(1, "Usage: %s IF [-p PORT] [-t TIMEOUT]\n\n"
 		     "Forwards IPX traffic between network interface "
 		     "IF where the real\ncomputers are located and DOSBox "
 		     "IPXNET.\n\nParameters:\n"
 		     " -p  UDP port where DOSBox connects to, defaults to 213\n"
+		     " -t  Packet read timeout in milliseconds\n"
+		     "     (Screamer Rally is unplayable without this option)\n"
 		     " -r  Use Novell raw IEEE 802.3 instead of LLC (IEEE 802.2)",
 		     argv[0]);
 	}
@@ -393,7 +400,7 @@ int main(int argc, char *argv[])
 	strncpy(device, argv[optind], sizeof(device));
 
 	// Open interface that has real DOS machine, in promiscuous mode
-	handle = pcap_open_live(device, BUFSIZ, 1, 0, errbuf);
+	handle = pcap_open_live(device, BUFSIZ, 1, timeout, errbuf);
 	if (!handle)
 	{
 		printf("Couldn't open device %s for pcap: %s\n", device, errbuf);
@@ -401,7 +408,9 @@ int main(int argc, char *argv[])
 	}
 	else
 	{
-		printf("Opened device %s for pcap\n", device);
+		printf("Opened device %s for pcap, "
+				"with a packet read timeout of %i\n"
+				, device, timeout);
 	}
 
 	// Start DosBox IPX server


### PR DESCRIPTION
This adds a packet reading timeout option for compatibility with games like Screamer Rally, which without a timeout, become unplayable (framerate drops to an absolutely ridiculous low on menu and when the race starts, no communication is established).

Also, fixed the -h help option not showing anything.