### PR TITLE
Ipxgw ethernetii bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /ipxgw
 *.o
+config.log
+config.status
+configure
+autom4te.cache/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+ifeq (,$(INSTALL))
+INSTALL = install
+endif
+
+ifeq ($(DESTDIR)$(bindir),)
+bindir = /bin
+endif
+
+bindir := $(DESTDIR)$(bindir)
+
 all: ipxgw
 
 ipxgw: ipxgw.o
@@ -8,3 +18,17 @@ ipxgw.o: ipxgw.cpp config.h
 
 clean:
 	rm -fv *.o ipxgw
+
+install: ipxgw
+	$(info Installing...)
+#Requiring user rights for pcap
+#Make sure that the group exists
+	@groupadd -f pcap
+ifneq (,$(PCAPUSER))
+	usermod -a -G pcap $(PCAPUSER)
+endif
+	$(INSTALL) -m 0755 ipxgw $(bindir)
+	$(info Adding pcap rights...)
+#Set the pcap rights to the app!
+	@chgrp pcap $(bindir)/ipxgw
+	@setcap cap_net_raw,cap_net_admin=eip $(bindir)/ipxgw

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,0 +1,56 @@
+# Makefile to build and install the SDL library
+
+top_builddir = .
+srcdir  = @srcdir@
+objects = build
+gen = gen
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+bindir	= @bindir@
+libdir  = @libdir@
+includedir = @includedir@
+datarootdir = @datarootdir@
+datadir	= @datadir@
+auxdir	= @datarootdir@/aux
+distpath = $(srcdir)/..
+distdir = $(BUILD_NAME)-@SDL_VERSION@
+distfile = $(distdir).tar.gz
+
+#@SET_MAKE@
+SHELL	= @SHELL@
+CC      = @CC@
+INCLUDE = -I$(includedir)
+CFLAGS  = 
+EXTRA_CFLAGS = 
+LDFLAGS = 
+EXTRA_LDFLAGS = 
+LIBTOOL = libtool
+INSTALL = install
+AR	= ar
+RANLIB	= ranlib
+WINDRES	= windres
+
+all: ipxgw
+
+ipxgw: ipxgw.o
+	g++ -Wall ipxgw.o `pkg-config --libs SDL_net` -lpcap -o ipxgw
+
+ipxgw.o: ipxgw.cpp config.h
+	g++ -Wall `pkg-config --cflags SDL_net` -c ipxgw.cpp
+
+clean:
+	rm -fv *.o ipxgw
+
+install: ipxgw
+	$(info Installing...)
+#Requiring user rights for pcap
+#Make sure that the group exists
+	@groupadd -f pcap
+ifneq (,$(PCAPUSER))
+	usermod -a -G pcap $(PCAPUSER)
+endif
+	$(INSTALL) -m 0755 ipxgw $(bindir)
+	$(info Adding pcap rights...)
+#Set the pcap rights to the app!
+	@chgrp pcap $(bindir)/ipxgw
+	@setcap cap_net_raw,cap_net_admin=eip $(bindir)/ipxgw

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,5 @@
+#This is to be run from the project's own autogen.sh in the project folder.
+git update-index --assume-unchanged Makefile
+aclocal || die "aclocal failed" # Set up an m4 environment
+autoconf || die "autoconf failed" # Generate configure from configure.ac
+echo Configure script is generated.

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,5 @@
+AC_INIT([ipxgw], [1.0])
+# AM_INIT_AUTOMAKE
+AC_PROG_CC
+AC_CONFIG_FILES([Makefile:Makefile.in])
+AC_OUTPUT

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -536,6 +536,7 @@ void IPX_ServerLoop() {
 		// Create and send packet received from DosBox to the real network
 		unsigned char ethernet[1500];
 		memset(&ethernet, 0, sizeof(ethernet)); //Clear!
+		--tmpHeader->transControl; //Received, don't increase the transport control field to count as a passthrough and let the receiving end apply this instead!
 
 		if (!use_ethernetii) //Not ethernet II?
 		{

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -329,7 +329,8 @@ static void ackClient(int client) {
 	SDLNet_Write32(ipconnNetwork[client], regHeader.src.network);
 	PackIP(ipxServerIp, &regHeader.src.addr.byIP);
 	SDLNet_Write16(0x2, regHeader.src.socket);
-	regHeader.transControl = 1; //Prevent deadlock by checking this field (identify this as a reply)!
+	regHeader.transControl = 0;
+	regHeader.pType = 2; //Echo reply!
 
 	regPacket.data = (Uint8 *)&regHeader;
 	regPacket.len = sizeof(regHeader);
@@ -403,6 +404,8 @@ static void requestClientEcho(int client) {
 	memset(&regHeader.dest.addr.byNode.node, 0xFF, 6); //Broadcast it!
 	SDLNet_Write16(0x2, regHeader.dest.socket);
 	regHeader.transControl = 0;
+	regHeader.pType = 0; //Echo request!
+
 
 	regPacket.data = (Uint8*)&regHeader;
 	regPacket.len = sizeof(regHeader);

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -341,6 +341,7 @@ static void ackClient(int client) {
 		printf("IPXSERVER: %s\n", SDLNet_GetError());
 		return; //Abort and don't perform the Ethernet ACK as well!
 	}
+	printf("ACK           -> box, IPX len=%i\n", regPacket.len);
 
 	//Also let the host network know that we allocated if on a Ethernet II network!
 	if (use_ethernetii) //Ethernet II used?
@@ -373,7 +374,7 @@ static void ackClient(int client) {
 		}
 		else
 		{
-			printf("ACK  -> real, IPX len=%i\n", regPacket.len);
+			printf("ACK           -> real, IPX len=%i\n", regPacket.len);
 		}
 	}
 }
@@ -408,6 +409,8 @@ static void requestClientEcho(int client) {
 	regPacket.maxlen = sizeof(regHeader);
 	regPacket.address = clientAddr; //Client's real address and port it's listening on!
 
+	printf("alloc request -> box, IPX len=%i\n", regPacket.len);
+
 	//Send to all Dosbox-clients to detect if they're used!
 	sendIPXPacket(regPacket.data, regPacket.len); //Send to all Dosbox clients!
 
@@ -433,7 +436,7 @@ static void requestClientEcho(int client) {
 		}
 		else
 		{
-			printf("alloc request  -> real, IPX len=%i\n", regPacket.len);
+			printf("alloc request -> real, IPX len=%i\n", regPacket.len);
 		}
 	}
 
@@ -526,6 +529,8 @@ void IPX_ServerLoop() {
 
 		// IPX packet is complete.  Now interpret IPX header and send to respective IP address
 		sendIPXPacket((Bit8u *)inPacket.data, inPacket.len);
+		printf("box           -> box, IPX len=%i\n", inPacket.len);
+
 
 		// Create and send packet received from DosBox to the real network
 		unsigned char ethernet[1500];
@@ -572,7 +577,7 @@ void IPX_ServerLoop() {
 		}
 		else
 		{
-			printf("box  -> real, IPX len=%i\n", inPacket.len);
+			printf("box           -> real, IPX len=%i\n", inPacket.len);
 		}
 	}
 }
@@ -626,7 +631,7 @@ void pcap_to_dosbox()
 			IPXHeader* tmpHeader = (IPXHeader*)(packet + ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0));
 			sendIPXPacket((Bit8u*)tmpHeader, header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
 
-			printf("real -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
+			printf("real          -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
 		}
 	}
 	else //Ethernet II?
@@ -679,7 +684,7 @@ void pcap_to_dosbox()
 				// Send to DOSBox
 				tmpHeader = (IPXHeader*)(packet + ETHER_HEADER_LEN);
 				sendIPXPacket((Bit8u*)tmpHeader, header->len - (ETHER_HEADER_LEN));
-				printf("real -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN));
+				printf("real          -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN));
 			}
 
 			//Check for timers!

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -501,6 +501,10 @@ void IPX_ServerLoop() {
 		IPXHeader *tmpHeader;
 		tmpHeader = (IPXHeader *)&inBuffer[0];
 		++tmpHeader->transControl; //Received, so increase the transport control field!
+		if (tmpHeader->transControl>=16) //16th hop discards?
+		{
+			return; //Discard!
+		}
 
 		if (SDLNet_Read32(tmpHeader->src.network)==0) { //Own network needs patching?
 			for(i=0;i<SOCKETTABLESIZE;i++) {
@@ -674,6 +678,10 @@ void pcap_to_dosbox()
 			// Send to DOSBox
 			IPXHeader* tmpHeader = (IPXHeader*)(packet + ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0));
 			++tmpHeader->transControl; //Received, so increase the transport control field!
+			if (tmpHeader->transControl>=16) //16th hop discards?
+			{
+				return; //Discard the packet!
+			}
 			sendIPXPacket((Bit8u*)tmpHeader, header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
 
 			printf("real          -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
@@ -694,6 +702,10 @@ void pcap_to_dosbox()
 				IPXHeader* tmpHeader;
 				tmpHeader = (IPXHeader*)&packet[ETHER_HEADER_LEN]; //The IPX packet!
 				++tmpHeader->transControl; //Received, so increase the transport control field!
+				if (tmpHeader->transControl>=16) //16th hop discards the packet!
+				{
+					return; //Discard the packet!
+				}
 
 				// Check to see if echo packet
 				if (SDLNet_Read16(tmpHeader->dest.socket) == 0x2) {

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -329,7 +329,7 @@ static void ackClient(int client) {
 	SDLNet_Write32(ipconnNetwork[client], regHeader.src.network);
 	PackIP(ipxServerIp, &regHeader.src.addr.byIP);
 	SDLNet_Write16(0x2, regHeader.src.socket);
-	regHeader.transControl = 0;
+	regHeader.transControl = 1; //Prevent deadlock by checking this field (identify this as a reply)!
 
 	regPacket.data = (Uint8 *)&regHeader;
 	regPacket.len = sizeof(regHeader);
@@ -468,7 +468,18 @@ void IPX_ServerLoop() {
 		// For this, I just spoofed the echo protocol packet designation 0x02
 		IPXHeader *tmpHeader;
 		tmpHeader = (IPXHeader *)&inBuffer[0];
-	
+		++tmpHeader->transControl; //Received, so increase the transport control field!
+
+		if (SDLNet_Read32(tmpHeader->src.network)==0) { //Own network needs patching?
+			for(i=0;i<SOCKETTABLESIZE;i++) {
+				if(connBuffer[i].connected==1) {
+					if (memcmp(&inPacket.address,&ipconn[i],4)==0) { //Found client?
+						SDLNet_Write32(ipconnNetwork[i], tmpHeader->dest.network); //Fixup source network to client network!
+					}
+				}
+			}		
+		}
+		
 		// Check to see if echo packet
 		if(SDLNet_Read16(tmpHeader->dest.socket) == 0x2) {
 			// Null destination node means its a server registration packet
@@ -535,6 +546,7 @@ void IPX_ServerLoop() {
 		// Create and send packet received from DosBox to the real network
 		unsigned char ethernet[1500];
 		memset(&ethernet, 0, sizeof(ethernet)); //Clear!
+		--tmpHeader->transControl; //Received, don't increase the transport control field to count as a passthrough and let the receiving end apply this instead!
 
 		if (!use_ethernetii) //Not ethernet II?
 		{
@@ -629,6 +641,7 @@ void pcap_to_dosbox()
 
 			// Send to DOSBox
 			IPXHeader* tmpHeader = (IPXHeader*)(packet + ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0));
+			++tmpHeader->transControl; //Received, so increase the transport control field!
 			sendIPXPacket((Bit8u*)tmpHeader, header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
 
 			printf("real          -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
@@ -647,7 +660,8 @@ void pcap_to_dosbox()
 				//Check for a registration packet.
 				// For this, I just spoofed the echo protocol packet designation 0x02
 				IPXHeader* tmpHeader;
-				tmpHeader = (IPXHeader*)&inBuffer[0x14]; //The IPX packet!
+				tmpHeader = (IPXHeader*)&packet[0x14]; //The IPX packet!
+				++tmpHeader->transControl; //Received, so increase the transport control field!
 
 				// Check to see if echo packet
 				if (SDLNet_Read16(tmpHeader->dest.socket) == 0x2) {

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -473,8 +473,8 @@ void IPX_ServerLoop() {
 		if (SDLNet_Read32(tmpHeader->src.network)==0) { //Own network needs patching?
 			for(i=0;i<SOCKETTABLESIZE;i++) {
 				if(connBuffer[i].connected==1) {
-					if (memcmp(&inPacket.address,&ipconn[i])==0) { //Found client?
-						SDLNet_Write32(ipconnNetwork[client], tmpHeader->dest.network); //Fixup source network to client network!
+					if (memcmp(&inPacket.address,&ipconn[i],4)==0) { //Found client?
+						SDLNet_Write32(ipconnNetwork[i], tmpHeader->dest.network); //Fixup source network to client network!
 					}
 				}
 			}		

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -39,6 +39,8 @@
 #define CONVIPX(hostvar) hostvar[0], hostvar[1], hostvar[2], hostvar[3], hostvar[4], hostvar[5]					// From DosBox
 #define IPXBUFFERSIZE 1424				// From DosBox
 #undef DEBUG							// More output if defined
+//Define below if you want to debug the network number functionality.
+//#define DEBUGNW
 
 //Timeout until a IPX node number is decided to be usable. Replies to the echo reset the timer until none reply within the timeout after the request.
 #define ALLOCATE_IPXNODE_ECHO_TIMEOUT 500000
@@ -122,10 +124,12 @@ packetBuffer connBuffer[SOCKETTABLESIZE];	// DosBOX
 Bit8u inBuffer[IPXBUFFERSIZE];				// DosBOX
 IPaddress ipconn[SOCKETTABLESIZE];  		// Active TCP/IP connection 
 IPaddress ipconnAssigned[SOCKETTABLESIZE];  		// Active TCP/IP connection's assigned IPX address!
+Uint32 ipconnNetwork[SOCKETTABLESIZE]; //The network number of the client!
 Uint16 port;								// UDP port to listen
 char device[20];							// Interface name
 bool use_llc = true; // Use Logical Link Control (IEEE 802.2)
 bool use_ethernetii = false; // Use Logical Link Control (IEEE 802.2)
+Uint32 use_IPXnetworknumber = 0; // Used network number for all clients!
 
 // From DosBox
 void UnpackIP(PackedIP ipPack, IPaddress * ipAddr) {
@@ -222,6 +226,8 @@ void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
 	Bit32u srchost, desthost;
 	Bit16u i;
 	Bits result;
+	Bit32u srcnetwork, dstnetwork;
+	Bit8u srcnetworkcur, dstnetworkcur; //Flags reflecting different network conditions
 	UDPpacket outPacket;
 	outPacket.channel = -1;
 	outPacket.data = buffer;
@@ -236,28 +242,55 @@ void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
 	srcport = tmpHeader->src.addr.byIP.port;
 	destport = tmpHeader->dest.addr.byIP.port;
 	
+	srcnetwork = SDLNet_Read32(tmpHeader->src.network); //Source network!
+	dstnetwork = SDLNet_Read32(tmpHeader->dest.network); //Destination network!
 
-	if(desthost == 0xffffffff) {
+	srcnetworkcur = dstnetworkcur = 0; //Init!
+
+	if((desthost == 0xffffffff) /* && (destport == 0xFFFF)*/) { //IPX node broadcast (this is officially both the host and port part having all bits set)?
 		// Broadcast
 		for(i=0;i<SOCKETTABLESIZE;i++) {
-			if((connBuffer[i].connected==1) && ((ipconnAssigned[i].host != srchost)||(ipconnAssigned[i].port!=srcport))) {
-				outPacket.address = ipconn[i];
-				result = SDLNet_UDP_Send(ipxServerSocket,-1,&outPacket);
-				if(result == 0) {
-					printf("IPXSERVER: %s\n", SDLNet_GetError());
-					continue;
+			if(connBuffer[i].connected==1) { //Ready for use?
+				srcnetworkcur = (((!srcnetwork)?1:0) | ((srcnetwork==ipconnNetwork[i])?2:0) | ((srcnetwork==0xFFFFFFFF)?4:0)); //Source network current or broadcast?
+				dstnetworkcur = (((!dstnetwork)?1:0) | ((dstnetwork==ipconnNetwork[i])?2:0) | ((dstnetwork==0xFFFFFFFF)?4:0)); //Destination network current or broadcast?
+				#ifdef DEBUGNW
+				printf("Test BC network %08x: src=%08x dst=%08x ours=%08x srcflags=%01x, dstflags=%01x\n", i, srcnetwork, dstnetwork, ipconnNetwork[i],srcnetworkcur,dstnetworkcur); //Log it for testing!
+				#endif
+				if (
+					(!((ipconnAssigned[i].host == srchost)&&(ipconnAssigned[i].port==srcport)&&(srcnetworkcur&1))) //Not from ourselves on our own network?
+					&& dstnetworkcur //And met any condition for the destination network?
+					) { //Valid to receive on this client?
+					#ifdef DEBUGNW
+					printf("Accepted condition!\n");
+					#endif
+					outPacket.address = ipconn[i];
+					result = SDLNet_UDP_Send(ipxServerSocket,-1,&outPacket);
+					if(result == 0) {
+						printf("IPXSERVER: %s\n", SDLNet_GetError());
+						continue;
+					}
 				}
 			}
 		}
 	} else {
 		// Specific address
 		for(i=0;i<SOCKETTABLESIZE;i++) {
-			if((connBuffer[i].connected==1) && (ipconnAssigned[i].host == desthost) && (ipconnAssigned[i].port == destport)) {
-				outPacket.address = ipconn[i];
-				result = SDLNet_UDP_Send(ipxServerSocket,-1,&outPacket);
-				if(result == 0) {
-					printf("IPXSERVER: %s\n", SDLNet_GetError());
-					continue;
+			if(connBuffer[i].connected==1) { //Ready for use?
+				srcnetworkcur = (((!srcnetwork)?1:0) | ((srcnetwork==ipconnNetwork[i])?2:0) | ((srcnetwork==0xFFFFFFFF)?4:0)); //Source network current or broadcast?
+				dstnetworkcur = (((!dstnetwork)?1:0) | ((dstnetwork==ipconnNetwork[i])?2:0) | ((dstnetwork==0xFFFFFFFF)?4:0)); //Destination network current or broadcast?
+				#ifdef DEBUGNW
+				printf("Test UC network %08x: src=%08x dst=%08x ours=%08x srcflags=%01x, dstflags=%01x\n", i, srcnetwork, dstnetwork, ipconnNetwork[i], srcnetworkcur, dstnetworkcur); //Log it for testing!
+				#endif
+				if ((ipconnAssigned[i].host == desthost) && (ipconnAssigned[i].port == destport) && dstnetworkcur) { //Conditions match the client (on current or specified network)?
+					#ifdef DEBUGNW
+					printf("Accepted condition!\n");
+					#endif
+					outPacket.address = ipconn[i];
+					result = SDLNet_UDP_Send(ipxServerSocket,-1,&outPacket);
+					if(result == 0) {
+						printf("IPXSERVER: %s\n", SDLNet_GetError());
+						continue;
+					}
 				}
 			}
 		}
@@ -280,11 +313,11 @@ static void ackClient(int client) {
 	SDLNet_Write16(sizeof(regHeader), regHeader.length);
 	
 	//Dosbox-compatible values here:
-	SDLNet_Write32(0, regHeader.dest.network);
+	SDLNet_Write32(ipconnNetwork[client], regHeader.dest.network); //Assigned network number!
 	PackIP(assignedAddr, &regHeader.dest.addr.byIP);
 	SDLNet_Write16(0x2, regHeader.dest.socket);
 
-	SDLNet_Write32(1, regHeader.src.network);
+	SDLNet_Write32(ipconnNetwork[client], regHeader.src.network);
 	PackIP(ipxServerIp, &regHeader.src.addr.byIP);
 	SDLNet_Write16(0x2, regHeader.src.socket);
 	regHeader.transControl = 0;
@@ -312,12 +345,12 @@ static void ackClient(int client) {
 		ethernet[13] = 0x37; //IPX over ethernet!
 
 		//Slight modification in the packet for the ACK on the host network! From assigned address to server node address to register (if any is listening)!
-		SDLNet_Write32(0, regHeader.src.network);
+		SDLNet_Write32(ipconnNetwork[client], regHeader.src.network);
 		PackIP(assignedAddr, &regHeader.src.addr.byIP);
 		SDLNet_Write16(0x2, regHeader.src.socket);
 
 		memcpy(&regHeader.dest.network,&ipx_servernetworknumber,4);
-		memcpy(& regHeader.dest.addr.byNode.node,&ipx_servernodeaddr,6); //Send to the a packet server registration, if any is listening and/or allocating!
+		memcpy(&regHeader.dest.addr.byNode.node,&ipx_servernodeaddr,6); //Send to the a packet server registration, if any is listening and/or allocating!
 		SDLNet_Write16(0x2, regHeader.dest.socket);
 
 		// IPX
@@ -351,12 +384,12 @@ static void requestClientEcho(int client) {
 	SDLNet_Write16(sizeof(regHeader), regHeader.length);
 
 	//Send it back to the client's requested address! This will also where it's returned to!
-	SDLNet_Write32(0, regHeader.src.network);
+	SDLNet_Write32(ipconnNetwork[client], regHeader.src.network);
 	PackIP(assignedAddr, &regHeader.src.addr.byIP);
 	SDLNet_Write16(0x2, regHeader.src.socket);
 
 	//And send from us (and received from them) as a broadcast!
-	SDLNet_Write32(0, regHeader.dest.network);
+	SDLNet_Write32(ipconnNetwork[client], regHeader.dest.network);
 	memset(&regHeader.dest.addr.byNode.node, 0xFF, 6); //Broadcast it!
 	SDLNet_Write16(0x2, regHeader.dest.socket);
 	regHeader.transControl = 0;
@@ -439,6 +472,11 @@ void IPX_ServerLoop() {
 						{
 							connBuffer[i].connected = 2; //Requesting IPX address from the host!
 							//Send a echo request packet on the host network to detect for collisions on used addresses!
+
+							//Setup the client's network number now!
+							ipconnNetwork[i] = use_IPXnetworknumber; //The network number for this client!
+
+							//Check for the first ipx node address to try assigning!
 							memcpy(&ipxaddr[0], &ipconnAssigned[i].host, 4); //Host!
 							memcpy(&ipxaddr[4], &ipconnAssigned[i].port, 2); //Port!
 							for (;IPXaddrused(&ipxaddr[0],&i);) //Skip addresses that are already being requested or used!
@@ -453,6 +491,9 @@ void IPX_ServerLoop() {
 						else //Just assume connected with available IPX node number!
 						{
 							connBuffer[i].connected = 1;
+							//Setup the client's network number now!
+							ipconnNetwork[i] = use_IPXnetworknumber; //The network number for this client!
+
 							host = ipconn[i].host;
 							printf("IPXSERVER: Connect from %d.%d.%d.%d\n", CONVIP(host));
 
@@ -665,11 +706,14 @@ int main(int argc, char *argv[])
 	bool help = false;
 	int c;
 
-	while ((c = getopt (argc, argv, "p:rhe")) != -1)
+	while ((c = getopt (argc, argv, "p:n:rhe")) != -1)
 		switch (c)
 		{
 		case 'p':
 			port = atoi(optarg);
+			break;
+		case 'n':
+			use_IPXnetworknumber = atoi(optarg);
 			break;
 		case 'r':
 			use_llc = false;
@@ -693,6 +737,7 @@ int main(int argc, char *argv[])
 		     "IF where the real\ncomputers are located and DOSBox "
 		     "IPXNET.\n\nParameters:\n"
 		     " -p  UDP port where DOSBox connects to, defaults to 213\n"
+		     " -n  IPX network number to use, defaults to 0\n"
 		     " -r  Use Novell raw IEEE 802.3 instead of LLC (IEEE 802.2)\n"
 		     " -e  Use Ethernet II instead of 802.3/802.2",
 		     argv[0]);

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -251,8 +251,11 @@ void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
 	Bits result;
 	Bit32u srcnetwork, dstnetwork;
 	Bit8u srcnetworkcur, dstnetworkcur; //Flags reflecting different network conditions
+#ifdef DEBUGNW
 	char ipxdst[20], ipxcur[20];
 	uint8_t ipxnode[6]; //IPX node number!
+#endif
+
 	UDPpacket outPacket;
 	outPacket.channel = -1;
 	outPacket.data = buffer;
@@ -260,7 +263,9 @@ void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
 	outPacket.maxlen = bufSize;
 	IPXHeader *tmpHeader;
 	tmpHeader = (IPXHeader *)buffer;
+#ifdef DEBUGNW
 	ipxdst[0] = ipxcur[0] = (char)0; //Init!
+#endif
 
 	srchost = tmpHeader->src.addr.byIP.host;
 	desthost = tmpHeader->dest.addr.byIP.host;

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -469,7 +469,17 @@ void IPX_ServerLoop() {
 		IPXHeader *tmpHeader;
 		tmpHeader = (IPXHeader *)&inBuffer[0];
 		++tmpHeader->transControl; //Received, so increase the transport control field!
-	
+
+		if (SDLNet_Read32(tmpHeader->src.network)==0) { //Own network needs patching?
+			for(i=0;i<SOCKETTABLESIZE;i++) {
+				if(connBuffer[i].connected==1) {
+					if (memcmp(&inPacket.address,&ipconn[i])==0) { //Found client?
+						SDLNet_Write32(ipconnNetwork[client], tmpHeader->dest.network); //Fixup source network to client network!
+					}
+				}
+			}		
+		}
+		
 		// Check to see if echo packet
 		if(SDLNet_Read16(tmpHeader->dest.socket) == 0x2) {
 			// Null destination node means its a server registration packet

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -677,7 +677,7 @@ void pcap_to_dosbox()
 	else //Ethernet II?
 	{
 		if (pcap_next_ex(handle,&header,&packet)<=0) return; //Poll manually!
-		if ((packet != 0) && (header->len >= (14 + 30))) //Ethernet Header and IPX header minimum length?
+		if ((packet != 0) && (header->len >= (ETHER_HEADER_LEN + 30))) //Ethernet Header and IPX header minimum length?
 		{
 			if ((packet[12] == 0x81) && (packet[13] == 0x37)) //IPX?
 			{
@@ -687,7 +687,7 @@ void pcap_to_dosbox()
 				//Check for a registration packet.
 				// For this, I just spoofed the echo protocol packet designation 0x02
 				IPXHeader* tmpHeader;
-				tmpHeader = (IPXHeader*)&packet[0x14]; //The IPX packet!
+				tmpHeader = (IPXHeader*)&packet[ETHER_HEADER_LEN]; //The IPX packet!
 				++tmpHeader->transControl; //Received, so increase the transport control field!
 
 				// Check to see if echo packet

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -474,7 +474,7 @@ void IPX_ServerLoop() {
 			for(i=0;i<SOCKETTABLESIZE;i++) {
 				if(connBuffer[i].connected==1) {
 					if (memcmp(&inPacket.address,&ipconn[i],4)==0) { //Found client?
-						SDLNet_Write32(ipconnNetwork[i], tmpHeader->dest.network); //Fixup source network to client network!
+						SDLNet_Write32(ipconnNetwork[i], tmpHeader->src.network); //Fixup source network to client network!
 					}
 				}
 			}		

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -505,6 +505,10 @@ void IPX_ServerLoop() {
 		{
 			return; //Discard!
 		}
+		if (memcmp(&tmpHeader->src.addr.byNode.node,&ipxbroadcastaddr,6)==0) //Broadcast source is forbidden?
+		{
+			return; //Discard!
+		}
 
 		if (SDLNet_Read32(tmpHeader->src.network)==0) { //Own network needs patching?
 			for(i=0;i<SOCKETTABLESIZE;i++) {
@@ -682,6 +686,11 @@ void pcap_to_dosbox()
 			{
 				return; //Discard the packet!
 			}
+			if (memcmp(&tmpHeader->src.addr.byNode.node,&ipxbroadcastaddr,6)==0) //Broadcast source is forbidden?
+			{
+				return; //Discard!
+			}
+			
 			sendIPXPacket((Bit8u*)tmpHeader, header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
 
 			printf("real          -> box , IPX len=%i\n", header->len - (ETHER_HEADER_LEN + (use_llc ? ENCAPSULE_LEN : 0)));
@@ -706,6 +715,11 @@ void pcap_to_dosbox()
 				{
 					return; //Discard the packet!
 				}
+				if (memcmp(&tmpHeader->src.addr.byNode.node,&ipxbroadcastaddr,6)==0) //Broadcast source is forbidden?
+				{
+					return; //Discard!
+				}
+				
 
 				// Check to see if echo packet
 				if (SDLNet_Read16(tmpHeader->dest.socket) == 0x2) {

--- a/ipxgw.cpp
+++ b/ipxgw.cpp
@@ -258,7 +258,7 @@ void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
 				#endif
 				if (
 					(!((ipconnAssigned[i].host == srchost)&&(ipconnAssigned[i].port==srcport)&&(srcnetworkcur&1))) //Not from ourselves on our own network?
-					&& dstnetworkcur //And met any condition for the destination network?
+					&& (dstnetworkcur & ((srcnetworkcur >> 1) | (srcnetworkcur >> 2) | srcnetworkcur | 6)) //And met any condition for the destination network (destination network 'current network' (zero) is only when source network is detected ours)?
 					) { //Valid to receive on this client?
 					#ifdef DEBUGNW
 					printf("Accepted condition!\n");
@@ -281,7 +281,9 @@ void sendIPXPacket(Bit8u *buffer, Bit16s bufSize) {
 				#ifdef DEBUGNW
 				printf("Test UC network %08x: src=%08x dst=%08x ours=%08x srcflags=%01x, dstflags=%01x\n", i, srcnetwork, dstnetwork, ipconnNetwork[i], srcnetworkcur, dstnetworkcur); //Log it for testing!
 				#endif
-				if ((ipconnAssigned[i].host == desthost) && (ipconnAssigned[i].port == destport) && dstnetworkcur) { //Conditions match the client (on current or specified network)?
+				if ((ipconnAssigned[i].host == desthost) && (ipconnAssigned[i].port == destport) &&
+					(dstnetworkcur & ((srcnetworkcur >> 1) | (srcnetworkcur >> 2) | srcnetworkcur | 6)) //And met any condition for the destination network (destination network 'current network' (zero) is only when source network is detected ours)?
+					) { //Conditions match the client (on current or specified network)?
 					#ifdef DEBUGNW
 					printf("Accepted condition!\n");
 					#endif


### PR DESCRIPTION
A little improvement on the IPX receiving (from both sides of the connection) to increase the transControl field in the IPX header. This allows connected clients to identify the packet having been routed through a IPX router and also makes detection of IPX echo vs echo replies possible (to prevent deadlocking on my own emulator, which won't send a IPX reply if it's increased past 1, to prevent replying to it's own IPX replies and flooding it's own network and causing a deadlock on itself).

I've also fixed some issue on the IPX reply check during allocation to actually check the fields in the header that was received, as inPacket isn't filled with the data when receiving packets from the Ethernet II connection.